### PR TITLE
analyze: fix to handle duplicate timestamps in benchmark data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ For etcd, we also recommend [etcd benchmark tool](https://github.com/coreos/etcd
 
 All logs and results can be found at https://console.cloud.google.com/storage/browser/dbtester-results
 
-
 <br><br><hr>
 ##### Write 1M keys, 1000-client, 256-byte key, 1KB value
 
@@ -37,12 +36,12 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+--------------------+------------------------+-----------------------+
 |      READS-COMPLETED-DELTA |                  6 |                    311 |                    15 |
 |    SECTORS-READS-DELTA-SUM |                  0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |              96474 |                  84881 |                940695 |
-|  SECTORS-WRITTEN-DELTA-SUM |             542512 |                9221640 |              41272068 |
-|          RECEIVE-BYTES-SUM |             4.9 GB |                 5.3 GB |                7.7 GB |
-|         TRANSMIT-BYTES-SUM |             3.7 GB |                 4.2 GB |                6.5 GB |
+| WRITES-COMPLETED-DELTA-SUM |              98301 |                  86583 |                941248 |
+|  SECTORS-WRITTEN-DELTA-SUM |             565344 |                9223784 |              41419484 |
+|          RECEIVE-BYTES-SUM |             5.0 GB |                 5.4 GB |                7.8 GB |
+|         TRANSMIT-BYTES-SUM |             3.8 GB |                 4.3 GB |                6.5 GB |
 |              MAX-CPU-USAGE |           291.56 % |               363.65 % |              226.18 % |
-|           MAX-MEMORY-USAGE |         1198.60 MB |             4688.05 MB |            4329.38 MB |
+|           MAX-MEMORY-USAGE |         1204.28 MB |             4689.33 MB |            4329.98 MB |
 |              TOTAL-SECONDS |        36.2024 sec |            61.0944 sec |          467.9311 sec |
 |             AVG-THROUGHPUT | 27622.4453 req/sec |     16298.0557 req/sec |     2137.0667 req/sec |
 |            SLOWEST-LATENCY |        246.4560 ms |           5570.6375 ms |         30388.9318 ms |
@@ -105,14 +104,14 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |                 0 |                    205 |                   141 |
+|      READS-COMPLETED-DELTA |                 0 |                    211 |                   141 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           4429435 |                4666587 |               7230463 |
-|  SECTORS-WRITTEN-DELTA-SUM |           2262752 |               14830288 |              81718092 |
+| WRITES-COMPLETED-DELTA-SUM |           4431218 |                4670825 |               7233188 |
+|  SECTORS-WRITTEN-DELTA-SUM |           2263660 |               14832440 |              81719964 |
 |          RECEIVE-BYTES-SUM |            5.8 GB |                 5.8 GB |                6.0 GB |
 |         TRANSMIT-BYTES-SUM |            4.6 GB |                 4.7 GB |                4.7 GB |
 |              MAX-CPU-USAGE |           52.02 % |                46.67 % |               84.40 % |
-|           MAX-MEMORY-USAGE |        1626.60 MB |             3568.49 MB |            3936.74 MB |
+|           MAX-MEMORY-USAGE |        1626.60 MB |             3568.67 MB |            3950.50 MB |
 |              TOTAL-SECONDS |      999.0083 sec |          1000.5091 sec |         1195.0587 sec |
 |             AVG-THROUGHPUT | 1000.9927 req/sec |       998.8554 req/sec |      836.7790 req/sec |
 |            SLOWEST-LATENCY |       198.1010 ms |           2392.6933 ms |         23594.1354 ms |
@@ -177,14 +176,14 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               186 |                    294 |                   383 |
+|      READS-COMPLETED-DELTA |               185 |                    293 |                   383 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           2091099 |                1668912 |               3973507 |
-|  SECTORS-WRITTEN-DELTA-SUM |           1175004 |               14572148 |              32486700 |
+| WRITES-COMPLETED-DELTA-SUM |           2090388 |                1667449 |               3966668 |
+|  SECTORS-WRITTEN-DELTA-SUM |           1173224 |               14349236 |              30568376 |
 |          RECEIVE-BYTES-SUM |            5.2 GB |                 5.4 GB |                8.9 GB |
-|         TRANSMIT-BYTES-SUM |            4.1 GB |                 4.3 GB |                7.7 GB |
-|              MAX-CPU-USAGE |           56.53 % |                56.39 % |               56.33 % |
-|           MAX-MEMORY-USAGE |        1472.87 MB |             3652.64 MB |            4561.35 MB |
+|         TRANSMIT-BYTES-SUM |            4.0 GB |                 4.3 GB |                7.7 GB |
+|              MAX-CPU-USAGE |           56.46 % |                56.26 % |               56.29 % |
+|           MAX-MEMORY-USAGE |        1466.26 MB |             3563.36 MB |            4545.72 MB |
 |              TOTAL-SECONDS |      570.7510 sec |           477.1301 sec |         1056.0748 sec |
 |             AVG-THROUGHPUT | 1752.0775 req/sec |      2090.3063 req/sec |      946.9027 req/sec |
 |            SLOWEST-LATENCY |       556.0183 ms |           3654.9846 ms |         17465.0180 ms |
@@ -249,14 +248,14 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+--------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4  | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+--------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |                  6 |                      4 |                    13 |
+|      READS-COMPLETED-DELTA |                  6 |                      4 |                    14 |
 |    SECTORS-READS-DELTA-SUM |                  0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |             332647 |                 646300 |               1115043 |
+| WRITES-COMPLETED-DELTA-SUM |             339249 |                 663603 |               1124580 |
 |  SECTORS-WRITTEN-DELTA-SUM |                  0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |             5.1 GB |                 5.3 GB |                5.6 GB |
-|         TRANSMIT-BYTES-SUM |             3.9 GB |                 4.2 GB |                4.4 GB |
-|              MAX-CPU-USAGE |           362.72 % |               388.31 % |              282.29 % |
-|           MAX-MEMORY-USAGE |         1213.43 MB |             9291.73 MB |            4523.80 MB |
+|          RECEIVE-BYTES-SUM |             5.2 GB |                 5.4 GB |                5.7 GB |
+|         TRANSMIT-BYTES-SUM |             4.0 GB |                 4.4 GB |                4.4 GB |
+|              MAX-CPU-USAGE |           363.53 % |               388.31 % |              282.29 % |
+|           MAX-MEMORY-USAGE |         1219.19 MB |             9291.80 MB |            4659.98 MB |
 |              TOTAL-SECONDS |        40.8774 sec |            30.3340 sec |          164.0401 sec |
 |             AVG-THROUGHPUT | 24463.3803 req/sec |     32964.2605 req/sec |     6096.0706 req/sec |
 |            SLOWEST-LATENCY |        150.4056 ms |           1565.8847 ms |          7306.8885 ms |
@@ -320,14 +319,14 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               473 |                    706 |                   571 |
+|      READS-COMPLETED-DELTA |               473 |                    712 |                   571 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           8257619 |                9913357 |              13254939 |
+| WRITES-COMPLETED-DELTA-SUM |           8263385 |                9922581 |              13261792 |
 |  SECTORS-WRITTEN-DELTA-SUM |                 0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |            6.5 GB |                 5.8 GB |                6.4 GB |
+|          RECEIVE-BYTES-SUM |            6.5 GB |                 5.9 GB |                6.4 GB |
 |         TRANSMIT-BYTES-SUM |            5.2 GB |                 4.7 GB |                5.1 GB |
 |              MAX-CPU-USAGE |           91.10 % |                64.88 % |              147.91 % |
-|           MAX-MEMORY-USAGE |        1694.38 MB |             2842.88 MB |            4231.91 MB |
+|           MAX-MEMORY-USAGE |        1696.60 MB |             2842.88 MB |            4231.98 MB |
 |              TOTAL-SECONDS |      999.0582 sec |           999.8117 sec |         1040.1450 sec |
 |             AVG-THROUGHPUT | 1000.9427 req/sec |       999.5752 req/sec |      961.4044 req/sec |
 |            SLOWEST-LATENCY |        56.0360 ms |           2635.4569 ms |          8546.8756 ms |
@@ -392,14 +391,14 @@ All logs and results can be found at https://console.cloud.google.com/storage/br
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               308 |                    217 |                   541 |
+|      READS-COMPLETED-DELTA |               308 |                    216 |                   532 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           3480190 |                3479238 |               6605626 |
+| WRITES-COMPLETED-DELTA-SUM |           3480145 |                3471343 |               6597902 |
 |  SECTORS-WRITTEN-DELTA-SUM |                 0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |            5.4 GB |                 5.5 GB |                5.8 GB |
-|         TRANSMIT-BYTES-SUM |            4.2 GB |                 4.4 GB |                4.5 GB |
-|              MAX-CPU-USAGE |          135.68 % |               122.75 % |              124.26 % |
-|           MAX-MEMORY-USAGE |        1333.86 MB |             6610.87 MB |            4790.88 MB |
+|          RECEIVE-BYTES-SUM |            5.4 GB |                 5.3 GB |                5.8 GB |
+|         TRANSMIT-BYTES-SUM |            4.2 GB |                 4.3 GB |                4.5 GB |
+|              MAX-CPU-USAGE |          135.68 % |               116.33 % |              124.26 % |
+|           MAX-MEMORY-USAGE |        1328.39 MB |             6276.01 MB |            4790.06 MB |
 |              TOTAL-SECONDS |      276.4103 sec |           185.1561 sec |          582.4233 sec |
 |             AVG-THROUGHPUT | 3617.8096 req/sec |      5400.8493 req/sec |     1716.9642 req/sec |
 |            SLOWEST-LATENCY |       155.0781 ms |           2140.8240 ms |          5637.2541 ms |

--- a/analyze/analyze_data_2_analyze_data.go
+++ b/analyze/analyze_data_2_analyze_data.go
@@ -123,7 +123,7 @@ func (data *analyzeData) aggSystemMetrics() error {
 					if err != nil {
 						return err
 					}
-					fv, _ := rowV.Number()
+					fv, _ := rowV.Float64()
 					frv := float64(fv) * 0.000001
 					if err = col.Set(rowIdx, dataframe.NewStringValue(fmt.Sprintf("%.2f", frv))); err != nil {
 						return err

--- a/analyze/analyze_data_5_plot.go
+++ b/analyze/analyze_data_5_plot.go
@@ -99,7 +99,7 @@ func points(col dataframe.Column) (plotter.XYs, error) {
 		if err != nil {
 			return nil, err
 		}
-		n, _ := v.Number()
+		n, _ := v.Float64()
 		pts[i].X = float64(i)
 		pts[i].Y = n
 	}

--- a/analyze/analyze_data_7_finalize_everything.go
+++ b/analyze/analyze_data_7_finalize_everything.go
@@ -124,7 +124,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					readsCompletedDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "SECTORS-READS-DELTA-"):
@@ -134,7 +134,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					sectorsReadDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "WRITES-COMPLETED-DELTA-"):
@@ -144,7 +144,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					writesCompletedDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "SECTORS-WRITTEN-DELTA-"):
@@ -154,7 +154,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					sectorsWrittenDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "RECEIVE-BYTES-NUM-DELTA-"):
@@ -164,7 +164,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					receiveBytesNumDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "TRANSMIT-BYTES-NUM-DELTA-"):
@@ -174,7 +174,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					transmitBytesNumDeltaSum += fv
 				}
 			case strings.HasPrefix(hdr, "AVG-CPU-"):
@@ -184,7 +184,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					maxAvgCPU = maxFloat64(maxAvgCPU, fv)
 				}
 			case strings.HasPrefix(hdr, "AVG-VMRSS-MB-"):
@@ -194,7 +194,7 @@ func do(configPath string) error {
 					if err != nil {
 						return err
 					}
-					fv, _ := vv.Number()
+					fv, _ := vv.Float64()
 					maxAvgVMRSSMBs = append(maxAvgVMRSSMBs, fv)
 				}
 			}
@@ -208,7 +208,7 @@ func do(configPath string) error {
 		row06TransmitBytesSum = append(row06TransmitBytesSum, humanize.Bytes(uint64(transmitBytesNumDeltaSum)))
 		row07MaxCPUUsage = append(row07MaxCPUUsage, fmt.Sprintf("%.2f %%", maxAvgCPU))
 
-		// linux sometimes returns overflowed value...
+		// TODO: linux sometimes returns overflowed value...
 		sort.Float64s(maxAvgVMRSSMBs)
 		row08MaxMemoryUsage = append(row08MaxMemoryUsage, fmt.Sprintf("%.2f MB", maxAvgVMRSSMBs[len(maxAvgVMRSSMBs)-2]))
 	}
@@ -397,7 +397,12 @@ func do(configPath string) error {
 		nf2 := dataframe.New()
 		for i := range clientNumColumns {
 			if clientNumColumns[i].Count() != dataColumns[i].Count() {
-				return fmt.Errorf("clientNumColumns[i].Count() %d != dataColumns[i].Count() %d", clientNumColumns[i].Count(), dataColumns[i].Count())
+				return fmt.Errorf("%q row count %d != %q row count %d",
+					clientNumColumns[i].Header(),
+					clientNumColumns[i].Count(),
+					dataColumns[i].Header(),
+					dataColumns[i].Count(),
+				)
 			}
 			if err := nf2.AddColumn(clientNumColumns[i]); err != nil {
 				return err
@@ -421,13 +426,13 @@ func do(configPath string) error {
 				if err != nil {
 					return err
 				}
-				num, _ := v1.Number()
+				num, _ := v1.Int64()
 
 				v2, err := dataColumns[i].Value(j)
 				if err != nil {
 					return err
 				}
-				data, _ := v2.Number()
+				data, _ := v2.Float64()
 
 				if v, ok := allData[int(num)]; ok {
 					allData[int(num)] = (v + data) / 2
@@ -449,7 +454,6 @@ func do(configPath string) error {
 			}
 
 			if i == 0 {
-				// col1 := dataframe.NewColumn(clientNumColumns[i].Header())
 				col1 := dataframe.NewColumn("CONTROL-CLIENT-NUM")
 				for j := range allKeys {
 					col1.PushBack(dataframe.NewStringValue(allKeys[j]))

--- a/bench-results/2017Q1-01-etcd-zookeeper-consul.md
+++ b/bench-results/2017Q1-01-etcd-zookeeper-consul.md
@@ -20,12 +20,12 @@
 +----------------------------+--------------------+------------------------+-----------------------+
 |      READS-COMPLETED-DELTA |                  6 |                    311 |                    15 |
 |    SECTORS-READS-DELTA-SUM |                  0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |              96474 |                  84881 |                940695 |
-|  SECTORS-WRITTEN-DELTA-SUM |             542512 |                9221640 |              41272068 |
-|          RECEIVE-BYTES-SUM |             4.9 GB |                 5.3 GB |                7.7 GB |
-|         TRANSMIT-BYTES-SUM |             3.7 GB |                 4.2 GB |                6.5 GB |
+| WRITES-COMPLETED-DELTA-SUM |              98301 |                  86583 |                941248 |
+|  SECTORS-WRITTEN-DELTA-SUM |             565344 |                9223784 |              41419484 |
+|          RECEIVE-BYTES-SUM |             5.0 GB |                 5.4 GB |                7.8 GB |
+|         TRANSMIT-BYTES-SUM |             3.8 GB |                 4.3 GB |                6.5 GB |
 |              MAX-CPU-USAGE |           291.56 % |               363.65 % |              226.18 % |
-|           MAX-MEMORY-USAGE |         1198.60 MB |             4688.05 MB |            4329.38 MB |
+|           MAX-MEMORY-USAGE |         1204.28 MB |             4689.33 MB |            4329.98 MB |
 |              TOTAL-SECONDS |        36.2024 sec |            61.0944 sec |          467.9311 sec |
 |             AVG-THROUGHPUT | 27622.4453 req/sec |     16298.0557 req/sec |     2137.0667 req/sec |
 |            SLOWEST-LATENCY |        246.4560 ms |           5570.6375 ms |         30388.9318 ms |
@@ -88,14 +88,14 @@
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |                 0 |                    205 |                   141 |
+|      READS-COMPLETED-DELTA |                 0 |                    211 |                   141 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           4429435 |                4666587 |               7230463 |
-|  SECTORS-WRITTEN-DELTA-SUM |           2262752 |               14830288 |              81718092 |
+| WRITES-COMPLETED-DELTA-SUM |           4431218 |                4670825 |               7233188 |
+|  SECTORS-WRITTEN-DELTA-SUM |           2263660 |               14832440 |              81719964 |
 |          RECEIVE-BYTES-SUM |            5.8 GB |                 5.8 GB |                6.0 GB |
 |         TRANSMIT-BYTES-SUM |            4.6 GB |                 4.7 GB |                4.7 GB |
 |              MAX-CPU-USAGE |           52.02 % |                46.67 % |               84.40 % |
-|           MAX-MEMORY-USAGE |        1626.60 MB |             3568.49 MB |            3936.74 MB |
+|           MAX-MEMORY-USAGE |        1626.60 MB |             3568.67 MB |            3950.50 MB |
 |              TOTAL-SECONDS |      999.0083 sec |          1000.5091 sec |         1195.0587 sec |
 |             AVG-THROUGHPUT | 1000.9927 req/sec |       998.8554 req/sec |      836.7790 req/sec |
 |            SLOWEST-LATENCY |       198.1010 ms |           2392.6933 ms |         23594.1354 ms |
@@ -160,14 +160,14 @@
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               186 |                    294 |                   383 |
+|      READS-COMPLETED-DELTA |               185 |                    293 |                   383 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           2091099 |                1668912 |               3973507 |
-|  SECTORS-WRITTEN-DELTA-SUM |           1175004 |               14572148 |              32486700 |
+| WRITES-COMPLETED-DELTA-SUM |           2090388 |                1667449 |               3966668 |
+|  SECTORS-WRITTEN-DELTA-SUM |           1173224 |               14349236 |              30568376 |
 |          RECEIVE-BYTES-SUM |            5.2 GB |                 5.4 GB |                8.9 GB |
-|         TRANSMIT-BYTES-SUM |            4.1 GB |                 4.3 GB |                7.7 GB |
-|              MAX-CPU-USAGE |           56.53 % |                56.39 % |               56.33 % |
-|           MAX-MEMORY-USAGE |        1472.87 MB |             3652.64 MB |            4561.35 MB |
+|         TRANSMIT-BYTES-SUM |            4.0 GB |                 4.3 GB |                7.7 GB |
+|              MAX-CPU-USAGE |           56.46 % |                56.26 % |               56.29 % |
+|           MAX-MEMORY-USAGE |        1466.26 MB |             3563.36 MB |            4545.72 MB |
 |              TOTAL-SECONDS |      570.7510 sec |           477.1301 sec |         1056.0748 sec |
 |             AVG-THROUGHPUT | 1752.0775 req/sec |      2090.3063 req/sec |      946.9027 req/sec |
 |            SLOWEST-LATENCY |       556.0183 ms |           3654.9846 ms |         17465.0180 ms |
@@ -232,14 +232,14 @@
 +----------------------------+--------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4  | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+--------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |                  6 |                      4 |                    13 |
+|      READS-COMPLETED-DELTA |                  6 |                      4 |                    14 |
 |    SECTORS-READS-DELTA-SUM |                  0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |             332647 |                 646300 |               1115043 |
+| WRITES-COMPLETED-DELTA-SUM |             339249 |                 663603 |               1124580 |
 |  SECTORS-WRITTEN-DELTA-SUM |                  0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |             5.1 GB |                 5.3 GB |                5.6 GB |
-|         TRANSMIT-BYTES-SUM |             3.9 GB |                 4.2 GB |                4.4 GB |
-|              MAX-CPU-USAGE |           362.72 % |               388.31 % |              282.29 % |
-|           MAX-MEMORY-USAGE |         1213.43 MB |             9291.73 MB |            4523.80 MB |
+|          RECEIVE-BYTES-SUM |             5.2 GB |                 5.4 GB |                5.7 GB |
+|         TRANSMIT-BYTES-SUM |             4.0 GB |                 4.4 GB |                4.4 GB |
+|              MAX-CPU-USAGE |           363.53 % |               388.31 % |              282.29 % |
+|           MAX-MEMORY-USAGE |         1219.19 MB |             9291.80 MB |            4659.98 MB |
 |              TOTAL-SECONDS |        40.8774 sec |            30.3340 sec |          164.0401 sec |
 |             AVG-THROUGHPUT | 24463.3803 req/sec |     32964.2605 req/sec |     6096.0706 req/sec |
 |            SLOWEST-LATENCY |        150.4056 ms |           1565.8847 ms |          7306.8885 ms |
@@ -303,14 +303,14 @@
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               473 |                    706 |                   571 |
+|      READS-COMPLETED-DELTA |               473 |                    712 |                   571 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           8257619 |                9913357 |              13254939 |
+| WRITES-COMPLETED-DELTA-SUM |           8263385 |                9922581 |              13261792 |
 |  SECTORS-WRITTEN-DELTA-SUM |                 0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |            6.5 GB |                 5.8 GB |                6.4 GB |
+|          RECEIVE-BYTES-SUM |            6.5 GB |                 5.9 GB |                6.4 GB |
 |         TRANSMIT-BYTES-SUM |            5.2 GB |                 4.7 GB |                5.1 GB |
 |              MAX-CPU-USAGE |           91.10 % |                64.88 % |              147.91 % |
-|           MAX-MEMORY-USAGE |        1694.38 MB |             2842.88 MB |            4231.91 MB |
+|           MAX-MEMORY-USAGE |        1696.60 MB |             2842.88 MB |            4231.98 MB |
 |              TOTAL-SECONDS |      999.0582 sec |           999.8117 sec |         1040.1450 sec |
 |             AVG-THROUGHPUT | 1000.9427 req/sec |       999.5752 req/sec |      961.4044 req/sec |
 |            SLOWEST-LATENCY |        56.0360 ms |           2635.4569 ms |          8546.8756 ms |
@@ -375,14 +375,14 @@
 +----------------------------+-------------------+------------------------+-----------------------+
 |                            | etcd-v3.1-go1.7.4 | zookeeper-r3.4.9-java8 | consul-v0.7.2-go1.7.4 |
 +----------------------------+-------------------+------------------------+-----------------------+
-|      READS-COMPLETED-DELTA |               308 |                    217 |                   541 |
+|      READS-COMPLETED-DELTA |               308 |                    216 |                   532 |
 |    SECTORS-READS-DELTA-SUM |                 0 |                      0 |                     0 |
-| WRITES-COMPLETED-DELTA-SUM |           3480190 |                3479238 |               6605626 |
+| WRITES-COMPLETED-DELTA-SUM |           3480145 |                3471343 |               6597902 |
 |  SECTORS-WRITTEN-DELTA-SUM |                 0 |                      0 |                     0 |
-|          RECEIVE-BYTES-SUM |            5.4 GB |                 5.5 GB |                5.8 GB |
-|         TRANSMIT-BYTES-SUM |            4.2 GB |                 4.4 GB |                4.5 GB |
-|              MAX-CPU-USAGE |          135.68 % |               122.75 % |              124.26 % |
-|           MAX-MEMORY-USAGE |        1333.86 MB |             6610.87 MB |            4790.88 MB |
+|          RECEIVE-BYTES-SUM |            5.4 GB |                 5.3 GB |                5.8 GB |
+|         TRANSMIT-BYTES-SUM |            4.2 GB |                 4.3 GB |                4.5 GB |
+|              MAX-CPU-USAGE |          135.68 % |               116.33 % |              124.26 % |
+|           MAX-MEMORY-USAGE |        1328.39 MB |             6276.01 MB |            4790.06 MB |
 |              TOTAL-SECONDS |      276.4103 sec |           185.1561 sec |          582.4233 sec |
 |             AVG-THROUGHPUT | 3617.8096 req/sec |      5400.8493 req/sec |     1716.9642 req/sec |
 |            SLOWEST-LATENCY |       155.0781 ms |           2140.8240 ms |          5637.2541 ms |

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 64d97bc0735b6db13c765596719ecf1409993a7c6f881480a7c7c09106dc9d0a
-updated: 2017-01-25T11:00:18.68845449-08:00
+hash: 0b3bfc64b15dbb144f15542b72a5b30f1e46c8d74907ee9043c7e66764b1813d
+updated: 2017-01-25T11:15:51.293166517-08:00
 imports:
 - name: bitbucket.org/zombiezen/gopdf
   version: 1c63dc69751bc45441c2ce1f56b631c55294b4d5
@@ -95,9 +95,9 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/gyuho/dataframe
-  version: 70365cbdcfbc465e03a6ec703137d6da35ef8e9b
+  version: ff668fdbafb3657733c2402b7de165265f179abf
 - name: github.com/gyuho/psn
-  version: 2877cb3cb574ed37efd271cb0c64938796d5a0af
+  version: 6c36a28085341b3ee3adbad19dc619482bcb9bae
   subpackages:
   - schema
 - name: github.com/hashicorp/consul

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 05f0491c2f47ba84f8c96ae53d37d2b74fc396fadd6b009a602e490b2977468d
-updated: 2017-01-24T12:04:10.726202771-08:00
+hash: 64d97bc0735b6db13c765596719ecf1409993a7c6f881480a7c7c09106dc9d0a
+updated: 2017-01-25T11:00:18.68845449-08:00
 imports:
 - name: bitbucket.org/zombiezen/gopdf
   version: 1c63dc69751bc45441c2ce1f56b631c55294b4d5
@@ -95,7 +95,7 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/gyuho/dataframe
-  version: 0654e1bff71a2c46f30d603f30b3621dd599ec50
+  version: 70365cbdcfbc465e03a6ec703137d6da35ef8e9b
 - name: github.com/gyuho/psn
   version: 2877cb3cb574ed37efd271cb0c64938796d5a0af
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -52,7 +52,7 @@ import:
   - vg/vgpdf
   - vg/vgsvg
 - package: github.com/gyuho/dataframe
-  version: 0654e1bff71a2c46f30d603f30b3621dd599ec50
+  version: 70365cbdcfbc465e03a6ec703137d6da35ef8e9b
 - package: github.com/gyuho/psn
   version: 2877cb3cb574ed37efd271cb0c64938796d5a0af
 - package: github.com/hashicorp/consul

--- a/glide.yaml
+++ b/glide.yaml
@@ -52,9 +52,9 @@ import:
   - vg/vgpdf
   - vg/vgsvg
 - package: github.com/gyuho/dataframe
-  version: 70365cbdcfbc465e03a6ec703137d6da35ef8e9b
+  version: ff668fdbafb3657733c2402b7de165265f179abf
 - package: github.com/gyuho/psn
-  version: 2877cb3cb574ed37efd271cb0c64938796d5a0af
+  version: 6c36a28085341b3ee3adbad19dc619482bcb9bae
 - package: github.com/hashicorp/consul
   version: 8d57727ff0d113a97c89a992e4681680f95cbf03
   subpackages:

--- a/vendor/github.com/gyuho/dataframe/column.go
+++ b/vendor/github.com/gyuho/dataframe/column.go
@@ -80,11 +80,11 @@ type Column interface {
 	// SortByStringDescending sorts Column in string descending order.
 	SortByStringDescending()
 
-	// SortByNumberAscending sorts Column in number(float) ascending order.
-	SortByNumberAscending()
+	// SortByFloat64Ascending sorts Column in number(float) ascending order.
+	SortByFloat64Ascending()
 
-	// SortByNumberDescending sorts Column in number(float) descending order.
-	SortByNumberDescending()
+	// SortByFloat64Descending sorts Column in number(float) descending order.
+	SortByFloat64Descending()
 
 	// SortByDurationAscending sorts Column in time.Duration ascending order.
 	SortByDurationAscending()
@@ -391,7 +391,7 @@ func (c *column) Copy() Column {
 
 func (c *column) SortByStringAscending()    { sort.Sort(ByStringAscending(c.data)) }
 func (c *column) SortByStringDescending()   { sort.Sort(ByStringDescending(c.data)) }
-func (c *column) SortByNumberAscending()    { sort.Sort(ByNumberAscending(c.data)) }
-func (c *column) SortByNumberDescending()   { sort.Sort(ByNumberDescending(c.data)) }
+func (c *column) SortByFloat64Ascending()   { sort.Sort(ByFloat64Ascending(c.data)) }
+func (c *column) SortByFloat64Descending()  { sort.Sort(ByFloat64Descending(c.data)) }
 func (c *column) SortByDurationAscending()  { sort.Sort(ByDurationAscending(c.data)) }
 func (c *column) SortByDurationDescending() { sort.Sort(ByDurationDescending(c.data)) }

--- a/vendor/github.com/gyuho/dataframe/dataframe.go
+++ b/vendor/github.com/gyuho/dataframe/dataframe.go
@@ -469,13 +469,13 @@ func (f *frame) Sort(header string, st SortType, so SortOption) error {
 			lesses = []LessFunc{StringDescendingFunc(idx)}
 		}
 
-	case SortType_Number:
+	case SortType_Float64:
 		switch so {
 		case SortOption_Ascending:
-			lesses = []LessFunc{NumberAscendingFunc(idx)}
+			lesses = []LessFunc{Float64AscendingFunc(idx)}
 
 		case SortOption_Descending:
-			lesses = []LessFunc{NumberDescendingFunc(idx)}
+			lesses = []LessFunc{Float64DescendingFunc(idx)}
 		}
 
 	case SortType_Duration:

--- a/vendor/github.com/gyuho/dataframe/sorter.go
+++ b/vendor/github.com/gyuho/dataframe/sorter.go
@@ -13,7 +13,7 @@ type (
 
 const (
 	SortType_String SortType = iota
-	SortType_Number
+	SortType_Float64
 	SortType_Duration
 )
 
@@ -45,7 +45,7 @@ func StringDescendingFunc(idx int) func(row1, row2 *[]string) bool {
 	}
 }
 
-func NumberAscendingFunc(idx int) func(row1, row2 *[]string) bool {
+func Float64AscendingFunc(idx int) func(row1, row2 *[]string) bool {
 	return func(row1, row2 *[]string) bool {
 		v1s := (*row1)[idx]
 		v1, _ := strconv.ParseFloat(v1s, 64)
@@ -55,7 +55,7 @@ func NumberAscendingFunc(idx int) func(row1, row2 *[]string) bool {
 	}
 }
 
-func NumberDescendingFunc(idx int) func(row1, row2 *[]string) bool {
+func Float64DescendingFunc(idx int) func(row1, row2 *[]string) bool {
 	return func(row1, row2 *[]string) bool {
 		v1s := (*row1)[idx]
 		v1, _ := strconv.ParseFloat(v1s, 64)

--- a/vendor/github.com/gyuho/dataframe/value.go
+++ b/vendor/github.com/gyuho/dataframe/value.go
@@ -36,6 +36,12 @@ func NewStringValue(v interface{}) Value {
 		return String(t)
 	case int:
 		return String(strconv.FormatInt(int64(t), 10))
+	case int64:
+		return String(strconv.FormatInt(t, 10))
+	case uint:
+		return String(strconv.FormatUint(uint64(t), 10))
+	case uint64:
+		return String(strconv.FormatUint(t, 10))
 	case float64:
 		return String(strconv.FormatFloat(t, 'f', -1, 64))
 	case time.Time:
@@ -43,7 +49,7 @@ func NewStringValue(v interface{}) Value {
 	case time.Duration:
 		return String(t.String())
 	default:
-		panic(fmt.Errorf("%v is not supported", v))
+		panic(fmt.Errorf("%v(%T) is not supported", v, v))
 	}
 	return nil
 }

--- a/vendor/github.com/gyuho/dataframe/value.go
+++ b/vendor/github.com/gyuho/dataframe/value.go
@@ -11,8 +11,14 @@ type Value interface {
 	// String parses Value to string. It returns false if not possible.
 	String() (string, bool)
 
-	// Number parses Value to float64. It returns false if not possible.
-	Number() (float64, bool)
+	// Int64 parses Value to int64. It returns false if not possible.
+	Int64() (int64, bool)
+
+	// Uint64 parses Value to uint64. It returns false if not possible.
+	Uint64() (uint64, bool)
+
+	// Float64 parses Value to float64. It returns false if not possible.
+	Float64() (float64, bool)
 
 	// Time parses Value to time.Time based on the layout. It returns false if not possible.
 	Time(layout string) (time.Time, bool)
@@ -30,6 +36,7 @@ type Value interface {
 	Copy() Value
 }
 
+// NewStringValue takes any interface and returns Value.
 func NewStringValue(v interface{}) Value {
 	switch t := v.(type) {
 	case string:
@@ -54,17 +61,29 @@ func NewStringValue(v interface{}) Value {
 	return nil
 }
 
+// NewStringValueNil returns an empty value.
 func NewStringValueNil() Value {
 	return String("")
 }
 
+// String defines string data types.
 type String string
 
 func (s String) String() (string, bool) {
 	return string(s), true
 }
 
-func (s String) Number() (float64, bool) {
+func (s String) Int64() (int64, bool) {
+	iv, err := strconv.ParseInt(string(s), 10, 64)
+	return iv, err == nil
+}
+
+func (s String) Uint64() (uint64, bool) {
+	iv, err := strconv.ParseUint(string(s), 10, 64)
+	return iv, err == nil
+}
+
+func (s String) Float64() (float64, bool) {
 	f, err := strconv.ParseFloat(string(s), 64)
 	return f, err == nil
 }
@@ -124,35 +143,35 @@ func (vs ByStringDescending) Less(i, j int) bool {
 	return vs1 > vs2
 }
 
-type ByNumberAscending []Value
+type ByFloat64Ascending []Value
 
-func (vs ByNumberAscending) Len() int {
+func (vs ByFloat64Ascending) Len() int {
 	return len(vs)
 }
 
-func (vs ByNumberAscending) Swap(i, j int) {
+func (vs ByFloat64Ascending) Swap(i, j int) {
 	vs[i], vs[j] = vs[j], vs[i]
 }
 
-func (vs ByNumberAscending) Less(i, j int) bool {
-	vs1, _ := vs[i].Number()
-	vs2, _ := vs[j].Number()
+func (vs ByFloat64Ascending) Less(i, j int) bool {
+	vs1, _ := vs[i].Float64()
+	vs2, _ := vs[j].Float64()
 	return vs1 < vs2
 }
 
-type ByNumberDescending []Value
+type ByFloat64Descending []Value
 
-func (vs ByNumberDescending) Len() int {
+func (vs ByFloat64Descending) Len() int {
 	return len(vs)
 }
 
-func (vs ByNumberDescending) Swap(i, j int) {
+func (vs ByFloat64Descending) Swap(i, j int) {
 	vs[i], vs[j] = vs[j], vs[i]
 }
 
-func (vs ByNumberDescending) Less(i, j int) bool {
-	vs1, _ := vs[i].Number()
-	vs2, _ := vs[j].Number()
+func (vs ByFloat64Descending) Less(i, j int) bool {
+	vs1, _ := vs[i].Float64()
+	vs2, _ := vs[j].Float64()
 	return vs1 > vs2
 }
 

--- a/vendor/github.com/gyuho/psn/list_ds_linux.go
+++ b/vendor/github.com/gyuho/psn/list_ds_linux.go
@@ -88,8 +88,8 @@ func ConvertDS(dss ...DSEntry) (header []string, rows [][]string) {
 	}
 	dataframe.SortBy(
 		rows,
-		dataframe.NumberDescendingFunc(5), // SectorsWritten
-		dataframe.NumberDescendingFunc(4), // SectorsRead
+		dataframe.Float64DescendingFunc(5), // SectorsWritten
+		dataframe.Float64DescendingFunc(4), // SectorsRead
 	).Sort(rows)
 
 	return

--- a/vendor/github.com/gyuho/psn/list_ns_linux.go
+++ b/vendor/github.com/gyuho/psn/list_ns_linux.go
@@ -79,8 +79,8 @@ func ConvertNS(nss ...NSEntry) (header []string, rows [][]string) {
 	}
 	dataframe.SortBy(
 		rows,
-		dataframe.NumberDescendingFunc(5), // ReceiveBytesNum
-		dataframe.NumberDescendingFunc(6), // TransmitBytesNum
+		dataframe.Float64DescendingFunc(5), // ReceiveBytesNum
+		dataframe.Float64DescendingFunc(6), // TransmitBytesNum
 	).Sort(rows)
 
 	return

--- a/vendor/github.com/gyuho/psn/list_ps_linux.go
+++ b/vendor/github.com/gyuho/psn/list_ps_linux.go
@@ -239,9 +239,9 @@ func ConvertPS(nss ...PSEntry) (header []string, rows [][]string) {
 	}
 	dataframe.SortBy(
 		rows,
-		dataframe.NumberDescendingFunc(12), // VMRSSNum
-		dataframe.NumberDescendingFunc(11), // CPUNum
-		dataframe.NumberDescendingFunc(13), // VMSizeNum
+		dataframe.Float64DescendingFunc(12), // VMRSSNum
+		dataframe.Float64DescendingFunc(11), // CPUNum
+		dataframe.Float64DescendingFunc(13), // VMSizeNum
 	).Sort(rows)
 
 	return


### PR DESCRIPTION
There was some duplicate or missing timestamps. Now it correctly handles them.

Or fix some index miscalculation.