### PR TITLE
control: bump up context timeout

### DIFF
--- a/control/step1_start_database.go
+++ b/control/step1_start_database.go
@@ -75,7 +75,10 @@ func sendReq(ep string, req agentpb.Request, i int) (*agentpb.Response, error) {
 	defer conn.Close()
 
 	cli := agentpb.NewTransporterClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second) // Consul takes longer
+
+	// give enough timeout
+	// e.g. uploading logs takes longer
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	resp, err := cli.Transfer(ctx, &req)
 	cancel()
 	if err != nil {

--- a/control/step4_upload_logs.go
+++ b/control/step4_upload_logs.go
@@ -24,6 +24,8 @@ import (
 )
 
 func step4UploadLogs(cfg Config) error {
+	plog.Info("step 4: uploading logs...")
+
 	if err := uploadToGoogle(cfg.Log, cfg); err != nil {
 		return err
 	}


### PR DESCRIPTION
Uploading logs takes several seconds to finish

Fix https://github.com/coreos/dbtester/issues.