### PR TITLE
test-configs: update Zookeeper r3.5.3-beta install script

### DIFF
--- a/agent/agent_zookeeper.go
+++ b/agent/agent_zookeeper.go
@@ -79,6 +79,7 @@ const (
 	JavaClassPathZookeeperr352alpha = `-cp zookeeper-3.5.2-alpha.jar:lib/slf4j-api-1.7.5.jar:lib/slf4j-log4j12-1.7.5.jar:lib/log4j-1.2.17.jar:conf org.apache.zookeeper.server.quorum.QuorumPeerMain`
 
 	// JavaClassPathZookeeperr353beta is the Java class paths of Zookeeper r3.5.3-beta.
+	// http://zookeeper.apache.org/doc/r3.5.3-beta/zookeeperAdmin.html#sc_zkMulitServerSetup
 	JavaClassPathZookeeperr353beta = `-cp zookeeper-3.5.3-beta.jar:lib/slf4j-api-1.7.5.jar:lib/slf4j-log4j12-1.7.5.jar:lib/log4j-1.2.17.jar:conf org.apache.zookeeper.server.quorum.QuorumPeerMain`
 )
 

--- a/test-configs/install-zookeeper-ubuntu.sh
+++ b/test-configs/install-zookeeper-ubuntu.sh
@@ -61,27 +61,30 @@ javac -version
 
 <<COMMENT
 ZK_VERSION=3.4.9
-sudo rm -rf $HOME/zookeeper
-sudo curl -sf -o /tmp/zookeeper-$ZK_VERSION.tar.gz -L https://www.apache.org/dist/zookeeper/zookeeper-$ZK_VERSION/zookeeper-$ZK_VERSION.tar.gz
-sudo tar -xzf /tmp/zookeeper-$ZK_VERSION.tar.gz -C /tmp/
-sudo mv /tmp/zookeeper-$ZK_VERSION /tmp/zookeeper
-sudo mv /tmp/zookeeper $HOME/
-sudo chmod -R 777 $HOME/zookeeper/
+rm -rf $HOME/zookeeper
+curl -sf -o /tmp/zookeeper-$ZK_VERSION.tar.gz -L https://www.apache.org/dist/zookeeper/zookeeper-$ZK_VERSION/zookeeper-$ZK_VERSION.tar.gz
+tar -xzf /tmp/zookeeper-$ZK_VERSION.tar.gz -C /tmp/
+mv /tmp/zookeeper-$ZK_VERSION /tmp/zookeeper
+mv /tmp/zookeeper $HOME/
+chmod -R 777 $HOME/zookeeper/
 mkdir -p $HOME/zookeeper/zookeeper.data
 touch $HOME/zookeeper/zookeeper.data/myid
-sudo chmod -R 777 $HOME/zookeeper/zookeeper.data/
+chmod -R 777 $HOME/zookeeper/zookeeper.data/
 COMMENT
 
-ZK_VERSION=3.5.3-beta
-sudo rm -rf $HOME/zookeeper
-sudo curl -sf -o /tmp/zookeeper-$ZK_VERSION.tar.gz -L https://www.apache.org/dist/zookeeper/zookeeper-$ZK_VERSION/zookeeper-$ZK_VERSION.tar.gz
-sudo tar -xzf /tmp/zookeeper-$ZK_VERSION.tar.gz -C /tmp/
-sudo mv /tmp/zookeeper-$ZK_VERSION /tmp/zookeeper
-sudo mv /tmp/zookeeper $HOME/
-sudo chmod -R 777 $HOME/zookeeper/
+# official zookeeper-3.5.3-beta.tar.gz is corrupted
+# errors when tar out, just use temporary zipped files
+rm -rf $HOME/zookeeper
+rm -rf $HOME/zookeeper-tmp
+rm -f $HOME/zookeeper-tmp.zip
+curl -sf -o $HOME/zookeeper-tmp.zip https://storage.googleapis.com/dbtester-results/zookeeper-3.5.3-beta.zip
+unzip $HOME/zookeeper-tmp.zip -d $HOME/zookeeper-tmp
+mv $HOME/zookeeper-tmp/zookeeper-3.5.3-beta $HOME/zookeeper
+rm -f $HOME/zookeeper-tmp.zip
+chmod -R 777 $HOME/zookeeper/
 mkdir -p $HOME/zookeeper/zookeeper.data
 touch $HOME/zookeeper/zookeeper.data/myid
-sudo chmod -R 777 $HOME/zookeeper/zookeeper.data/
+chmod -R 777 $HOME/zookeeper/zookeeper.data/
 
 cd $HOME/zookeeper
 ls $HOME/zookeeper


### PR DESCRIPTION
tar file is corrupted for linux

Fix https://github.com/coreos/dbtester/issues/343.